### PR TITLE
UI tweaks to ease error investigation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+    "presets": ["es2015", "react"]
+}

--- a/package.json
+++ b/package.json
@@ -9,14 +9,18 @@
   "description": "Simple static site to display NetKAN indexing status",
   "keywords": [],
   "dependencies": {
+    "ajv": "^5.2.2",
+    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-react": "^6.24.1",
     "bootstrap": "^3.3.5",
-    "css-loader": "^0.17.0",
-    "fixed-data-table": "^0.4.6",
-    "jquery": "^2.1.4",
-    "moment": "~2.10.6",
-    "react": "^0.13.3",
+    "css-loader": "^0.28.7",
+    "fixed-data-table": "^0.6.4",
+    "jquery": "^3.2.1",
+    "moment": "~2.18.1",
+    "react": "^15.6.1",
+    "react-dom": "^15.6.1",
     "require": "~2",
-    "style-loader": "^0.12.3"
+    "style-loader": "^0.18.2"
   },
   "repository": {
     "type": "git",
@@ -25,9 +29,9 @@
   "author": "Leon Wright",
   "license": "MIT",
   "devDependencies": {
-    "babel-core": "^5.8.23",
-    "babel-loader": "^5.3.2",
-    "html-webpack-plugin": "^1.6.1",
-    "webpack": "^1.12.0"
+    "babel-core": "^6.10.4",
+    "babel-loader": "^7.1.2",
+    "html-webpack-plugin": "^2.30.1",
+    "webpack": "^3.5.6"
   }
 }

--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -1,11 +1,17 @@
 import React from 'react';
+import ReactDom from 'react-dom';
 import NetKANs from './components/NetKANs.jsx';
 import datatableStyles from
-  '../../node_modules/fixed-data-table/dist/fixed-data-table.min.css'
+  '../../node_modules/fixed-data-table/dist/fixed-data-table.min.css';
+
+var sheet = document.createElement('style');
+sheet.type = 'text/css';
+sheet.innerHTML = 'html,body{background-color:#f0f0f0;} input::-webkit-input-placeholder{font-style:italic;}';
+document.body.appendChild(sheet);
 
 document.body.innerHTML += '<div id="content"></div>';
 
-React.render(
+ReactDom.render(
   <NetKANs
     url="http://status.ksp-ckan.org/status/netkan.json"
     pollInterval={300000} />,

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -19,8 +19,8 @@ export default class NetKANs extends React.Component {
       tableHeight: 500,
       filterBy: 'failed',
       filterId: null,
-      sortBy: 'id',
-      sortDir: 'ASC'
+      sortBy: 'last_error',
+      sortDir: 'DESC'
     }
 
     if (window.addEventListener) {
@@ -66,10 +66,10 @@ export default class NetKANs extends React.Component {
     this._updateTimer = setTimeout(this._updateTableSize, 16);
   }
   _updateTableSize() {
-    const widthOffset = window.innerWidth < 680 ? 0 : 240;
+    const widthOffset = window.innerWidth < 680 ? 0 : 20;
     this.setState({
       tableWidth: window.innerWidth - widthOffset,
-      tableHeight: window.innerHeight - 200,
+      tableHeight: window.innerHeight - 50,
     });
   }
   _onFilterChange(e) {
@@ -88,8 +88,9 @@ export default class NetKANs extends React.Component {
 
     const rows = this.state.filterId ?
       this.state.data.filter((row) => {
-        return row['id'].toLowerCase()
-          .indexOf(this.state.filterId.toLowerCase()) !== -1
+          var filt = this.state.filterId.toLowerCase();
+        return (row['id'].toLowerCase().indexOf(filt) !== -1)
+          || (row['last_error'] && row['last_error'].toLowerCase().indexOf(filt) !== -1);
       }) : this.state.data;
 
     rows.sort((a, b) => {
@@ -114,16 +115,36 @@ export default class NetKANs extends React.Component {
         return ''
       }
       return this.state.sortDir === 'DESC' ?
-        ' ↓' : ' ↑'
+        ' ▾' : ' ▴'
+    };
+
+    const divstyle = {
+      fontSize: '9pt'
+    };
+    const h1style = {
+      color:              '#333',
+      fontSize:           '16pt',
+      margin:             '5px 0',
+      paddingLeft:        '72px',
+      backgroundImage:    'url(favicon.ico)',
+      backgroundPosition: 'left center',
+      backgroundRepeat:   'no-repeat'
+    };
+    const inputstyle = {
+      float:    'right',
+      margin:   '1px 5px',
+      width:    '20em',
+      fontSize: '11pt',
+      padding:  '1px 3px'
     };
 
     return (
-      <div>
-        <h1>NetKANs Indexed</h1>
-        <input onChange={this._onFilterChange} placeholder='Filter by NetKAN' />
+      <div style={divstyle}>
+        <input onChange={this._onFilterChange} placeholder='filter...' style={inputstyle} autoFocus='true' type='search' />
+        <h1 style={h1style}>NetKANs Indexed</h1>
         <Table
-          rowHeight={50}
-          headerHeight={50}
+          rowHeight={40}
+          headerHeight={30}
           rowGetter={index => rows[index]}
           rowsCount={rows.length}
           width={this.state.tableWidth}
@@ -136,7 +157,7 @@ export default class NetKANs extends React.Component {
             fixed={true}
             label={'NetKAN' + sortDirArrow('id')}
             width={200}
-            flexGrow={4}
+            flexGrow={1}
           />
           <Column
             headerRenderer={this._renderHeader.bind(this)}
@@ -144,8 +165,8 @@ export default class NetKANs extends React.Component {
             dataKey="last_checked"
             fixed={true}
             label={'Last Checked' + sortDirArrow('last_checked')}
-            width={100}
-            flexGrow={1}
+            width={120}
+            flexGrow={0}
           />
           <Column
             headerRenderer={this._renderHeader.bind(this)}
@@ -153,8 +174,8 @@ export default class NetKANs extends React.Component {
             dataKey="last_inflated"
             fixed={true}
             label={'Last Inflated' + sortDirArrow('last_inflated')}
-            width={100}
-            flexGrow={1}
+            width={120}
+            flexGrow={0}
           />
           <Column
             headerRenderer={this._renderHeader.bind(this)}
@@ -162,16 +183,16 @@ export default class NetKANs extends React.Component {
             dataKey="last_indexed"
             fixed={true}
             label={'Last Indexed' + sortDirArrow('last_indexed')}
-            width={100}
-            flexGrow={1}
+            width={120}
+            flexGrow={0}
           />
           <Column
             headerRenderer={this._renderHeader.bind(this)}
             dataKey="last_error"
-            fixed={true}
+            fixed={false}
             label={'Last Error' + sortDirArrow('last_error')}
             width={200}
-            flexGrow={1}
+            flexGrow={4}
           />
         </Table>
       </div>

--- a/webpack.build.config.js
+++ b/webpack.build.config.js
@@ -1,10 +1,11 @@
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 var webpack = require('webpack');
+var path = require('path');
 
 module.exports = {
   entry: './src/javascript/app.jsx',
   output: {
-    path: 'dist',
+    path: path.resolve(__dirname, 'dist'),
     filename: 'index_bundle.js'
   },
   module: {


### PR DESCRIPTION
Some of the longer NetKAN errors were being cut off in the [status page](http://status.ksp-ckan.org/), so I decided to try improve the layout. See the commit message for details.

(Dependencies updated to latest versions, which in turn meant updating some API calls.)

Before:

> ![image](https://user-images.githubusercontent.com/1559108/30244683-ca7e0d98-9588-11e7-8213-d5bc81f51ede.png)

After:

> ![image](https://user-images.githubusercontent.com/1559108/30244697-176f6cbe-9589-11e7-92b6-5d393f3e57c9.png)
