### PR TITLE
Add links to netkans

### DIFF
--- a/src/javascript/app.jsx
+++ b/src/javascript/app.jsx
@@ -6,7 +6,7 @@ import datatableStyles from
 
 var sheet = document.createElement('style');
 sheet.type = 'text/css';
-sheet.innerHTML = 'html,body{background-color:#f0f0f0;} input::-webkit-input-placeholder{font-style:italic;}';
+sheet.innerHTML = 'html,body{background-color:#f0f0f0;} input::-webkit-input-placeholder{font-style:italic;} a:link,a:visited{text-decoration:none;color:#009;} a:hover,a:active{text-decoration:underline;}';
 document.body.appendChild(sheet);
 
 document.body.innerHTML += '<div id="content"></div>';

--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -153,6 +153,7 @@ export default class NetKANs extends React.Component {
           overflowY="auto">
           <Column
             headerRenderer={this._renderHeader.bind(this)}
+            cellRenderer={id => <a href={"https://github.com/KSP-CKAN/NetKAN/tree/master/NetKAN/" + id + ".netkan"}>{id}</a>}
             dataKey="id"
             fixed={true}
             label={'NetKAN' + sortDirArrow('id')}


### PR DESCRIPTION
It's handy to be able to jump to the main netkan entry for a package, so this change makes the package names into links.

(It would be even nicer to have a link to the package's page on SpaceDock or GitHub depending on the download host site, but that would require quite a lot more parsing than is currently done.)