### PR TITLE
Fix NRE when a status object is null

### DIFF
--- a/src/javascript/components/NetKANs.jsx
+++ b/src/javascript/components/NetKANs.jsx
@@ -30,8 +30,8 @@ export default class NetKANs extends React.Component {
     } else {
       window.onresize = this._onResize;
     }
-    this.loadNetKANsFromServer();
     setInterval(this.loadNetKANsFromServer, this.props.pollInterval);
+    this.loadNetKANsFromServer();
   }
   loadNetKANsFromServer() {
     $.ajax({
@@ -40,7 +40,7 @@ export default class NetKANs extends React.Component {
       cache: 'false',
       success: (data) => {
         const netkan = Object.keys(data).map((key) => {
-          const item = data[key];
+          const item = data[key] ? data[key] : {};
           item.id = key;
           return item;
         });


### PR DESCRIPTION
## Problem

The status page is having a problem currently; it's not loading:

![image](https://user-images.githubusercontent.com/1559108/59553864-06463000-8f8b-11e9-96de-06bdb720ade0.png)

## Cause

```
index_bundle.js:57 Uncaught TypeError: Cannot set property 'id' of null
    at index_bundle.js:20
    at Array.map (<anonymous>)
    at Object.success (index_bundle.js:20)
    at u (index_bundle.js:57)
    at Object.fireWith [as resolveWith] (index_bundle.js:57)
    at o (index_bundle.js:57)
    at XMLHttpRequest.<anonymous> (index_bundle.js:57)
```

That happens here:

https://github.com/techman83/NetKAN-status/blob/dae7ef5d580dc73fa955c3327005458c8bf498d1/src/javascript/components/NetKANs.jsx#L43-L44

... because some of the status objects are null:

```sh
$ wget -O - http://status.ksp-ckan.space/status/netkan.json | python -m json.tool | egrep '^    ".*null'

    "ScottMunley": null,
    "SuperfluousNodes": null,
    "TESSSatellite": null,
    "XDHorribleWeapons": null,
```

All of those modules were added in the last 24 hours or so, and figuring out why they're null is next on my to-do list.

## Changes

Now if `data[key]` is null, we fall back to creating a new empty object, which happily allows an `id` property to be set. This should populate a mostly blank row to signify that the module is present but null.

I also moved the `setInterval` call for the 5 minute timer to be before the first call to `loadNetKANsFromServer`, to ensure the timer is still set up even if that function throws an exception. This will help with debugging, since you can fix something in your browser's debugger and wait 5 minutes to see if it works.